### PR TITLE
fix catgory generation during tremor transform

### DIFF
--- a/packages/tremor/src/timeseries.tsx
+++ b/packages/tremor/src/timeseries.tsx
@@ -70,7 +70,12 @@ export function toTremorTimeseriesData<
     });
     return output;
   });
-  const categories = Object.keys(data.at(0) ?? {}).filter((x) => x !== "label");
+  const categories = [
+    ...new Set(
+      data.flatMap((d) => Object.keys(d).filter((key) => key !== "label")),
+    ),
+  ];
+  
   return { data, categories, labels };
 }
 


### PR DESCRIPTION
When rendering tremor graphs, if the first item in the series lacks a label then the data is not transformed properly. This PR fixes this, and makes sure to include labels from all items in the series.