### PR TITLE
make time series continuous

### DIFF
--- a/packages/tremor/src/timeseries.tsx
+++ b/packages/tremor/src/timeseries.tsx
@@ -58,7 +58,7 @@ export function toTremorTimeseriesData<
       }
       if (isChartData(val)) {
         const num = val.data[index];
-        if (num) output[val.label] = num;
+        output[val.label] = num ?? 0;
         output["label"] = labels[index]!;
       } else {
         Object.values(val).forEach((valEntry: ChartData) => {


### PR DESCRIPTION
Currently when time series data has 0 values line charts do not properly, showing singular disparate dots intstead of lines.

Before 
<img width="890" alt="Screenshot 2024-03-03 at 6 56 45 AM" src="https://github.com/RhysSullivan/typelytics/assets/1767032/d06238af-0079-453c-b858-1e4615b96d4d">

After
<img width="892" alt="Screenshot 2024-03-03 at 6 56 31 AM" src="https://github.com/RhysSullivan/typelytics/assets/1767032/261a7e64-e16a-4c2b-b6e6-f9ebc984d91f">
